### PR TITLE
Updated XRControllerInputRemapper. The changes made to XRControllerIn…

### DIFF
--- a/Assets/com.edia.core/Runtime/Base/Scripts/XR/XRControllerInputRemapper.cs
+++ b/Assets/com.edia.core/Runtime/Base/Scripts/XR/XRControllerInputRemapper.cs
@@ -56,7 +56,9 @@ namespace Edia.XR {
 			if (index < 0) return;
 
 			Redirectors[index].isEnabled = onOff;
-			
+
+			if (!isActiveAndEnabled) return;
+
 			if (onOff) Subscribe(Redirectors[index]);
 			else Unsubscribe(Redirectors[index]);
 		}

--- a/Assets/com.edia.core/Runtime/Base/Scripts/XR/XRControllerInputRemapper.cs
+++ b/Assets/com.edia.core/Runtime/Base/Scripts/XR/XRControllerInputRemapper.cs
@@ -8,7 +8,7 @@ namespace Edia.XR {
 	/// <summary>In order to be flexible for each Xblock, the remapping of a controller key to a method is a separate script</summary>
 	[System.Serializable]
 	[AddComponentMenu("EDIA/XR Remap Controller Input")]
-	public class XRControllerInputRemapper : MonoBehaviour {
+	public class XRControllerInputRemapperNew : MonoBehaviour {
 
 		// TODO Allow multiple input actions to one ID
 		// TODO Input remapping should take systems 'allowed interaction' into considiration
@@ -19,13 +19,23 @@ namespace Edia.XR {
 			public bool isEnabled = false;
 			public InputActionReference inputActionSubmit;
 			public UnityEvent<InputAction.CallbackContext> methodToCall;
+
+			internal bool isSubscribed = false;
 		}
 
 		public List<ControllerInputRemap> Redirectors = new List<ControllerInputRemap>();
 
-		private void Start() {
+		private void OnEnable() {
 			foreach (ControllerInputRemap r in Redirectors) {
-				EnableRemapping(r.id, r.isEnabled);
+				if (r.isEnabled) {
+					Subscribe(r);
+				}
+			}
+		}
+
+		private void OnDisable() {
+			foreach (ControllerInputRemap r in Redirectors) {
+				Unsubscribe(r);
 			}
 		}
 
@@ -43,10 +53,28 @@ namespace Edia.XR {
 		/// <param name="onOff">active</param>
 		public void EnableRemapping (string id, bool onOff) {
 			int index = Redirectors.FindIndex(x => x.id == id);
+			if (index < 0) return;
+
+			Redirectors[index].isEnabled = onOff;
 			
-			if (onOff) Redirectors[index].inputActionSubmit.action.performed += Redirectors[index].methodToCall.Invoke;
-			else Redirectors[index].inputActionSubmit.action.performed -= Redirectors[index].methodToCall.Invoke;
+			if (onOff) Subscribe(Redirectors[index]);
+			else Unsubscribe(Redirectors[index]);
 		}
 
+		private void Subscribe(ControllerInputRemap r) {
+			if (r.isSubscribed || r.inputActionSubmit == null || r.inputActionSubmit.action == null) return;
+			
+			r.inputActionSubmit.action.Enable();
+			r.inputActionSubmit.action.performed += r.methodToCall.Invoke;
+			r.isSubscribed = true;
+		}
+
+		private void Unsubscribe(ControllerInputRemap r) {
+			if (!r.isSubscribed || r.inputActionSubmit == null || r.inputActionSubmit.action == null) return;
+
+			r.inputActionSubmit.action.performed -= r.methodToCall.Invoke;
+			// Note: We don't disable the action here as other components might be using the same InputActionReference
+			r.isSubscribed = false;
+		}
 	}
 }

--- a/Assets/com.edia.core/Runtime/Base/Scripts/XR/XRControllerInputRemapper.cs
+++ b/Assets/com.edia.core/Runtime/Base/Scripts/XR/XRControllerInputRemapper.cs
@@ -8,7 +8,7 @@ namespace Edia.XR {
 	/// <summary>In order to be flexible for each Xblock, the remapping of a controller key to a method is a separate script</summary>
 	[System.Serializable]
 	[AddComponentMenu("EDIA/XR Remap Controller Input")]
-	public class XRControllerInputRemapperNew : MonoBehaviour {
+	public class XRControllerInputRemapper : MonoBehaviour {
 
 		// TODO Allow multiple input actions to one ID
 		// TODO Input remapping should take systems 'allowed interaction' into considiration


### PR DESCRIPTION
It seems that unity updated some things in their input system.
Some changes were needed in the remapper script, also some validations are added to avoid exceptions and leftovers.


A.i claims:
…putRemapperNew.cs are fully compatible with versions of the Unity Input System package prior to 1.19.0 (including versions as old as 1.0.0).