### PR TITLE
Guard trial rows against a key/value count mismatch (#62)

### DIFF
--- a/Assets/com.edia.core/Runtime/Base/Scripts/Experiment/SessionGenerator.cs
+++ b/Assets/com.edia.core/Runtime/Base/Scripts/Experiment/SessionGenerator.cs
@@ -294,7 +294,20 @@ namespace Edia {
                             AddToConsole($"No trial settings found for XBlock <b>{currentXBlock.subType}</b>. Adding an empty trial.");
                         }
                         else {
-                            foreach (ValueList row in currentXBlock.trialSettings.valueList) {
+                            var trialKeys = currentXBlock.trialSettings.keys;
+
+                            for (var r = 0; r < currentXBlock.trialSettings.valueList.Count; r++) {
+                                ValueList row = currentXBlock.trialSettings.valueList[r];
+
+                                // Every row must hold exactly one value per key: the loop below looks up
+                                // trialKeys[i] by value position, so a longer row would index past the key list.
+                                if (row.values.Count != trialKeys.Count) {
+                                    AddToConsole(
+                                        $"XBlock <b>{currentXBlock.subType}</b>: row {r + 1} of 'valueList' holds {row.values.Count} value(s), but {trialKeys.Count} key(s) are defined ({string.Join(", ", trialKeys)}). Give every row exactly one value per key in {blockId}.json.",
+                                        LogType.Error);
+                                    return false;
+                                }
+
                                 Trial trial = newBlock.CreateTrial();
 
                                 for (var i = 0; i < row.values.Count; i++) {


### PR DESCRIPTION
Fixes #62.

`SessionGenerator` walked each row of `trialSettings.valueList` and looked up `trialSettings.keys[i]` by value position. A row holding more values than there are keys therefore indexed past the end of the key list:

```
ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
```

The exception named neither the block nor the row, and it fired after `CreateTrial()` had already run, leaving a half-filled trial behind.

Rows are now checked before the trial is created. A mismatch is reported through the same validation console as the other config errors and aborts generation, e.g.:

> XBlock **template**: row 3 of 'valueList' holds 6 value(s), but 5 key(s) are defined (cue, duration, isi, target, feedback). Give every row exactly one value per key in task-template.json.

The identical patch was compiled and tested on the upgrade branch this was written alongside: recompile clean (0 errors, 0 warnings) and the EditMode suite at 67/68 passed, 0 failed, 1 skipped. That branch carries the same code in this region but a different surrounding codebase, so this branch itself still deserves a compile before merging.
